### PR TITLE
Add regex support on allowedClasses on 1.22.1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -587,8 +587,13 @@ function sanitizeHtml(html, options, _recursing) {
       return classes;
     }
     classes = classes.split(/\s+/);
-    return classes.filter(function(clss) {
-      return allowed.indexOf(clss) !== -1;
+    return classes.filter(function (clss) {
+      return allowed.some(function (allowedElem) {
+        if (allowedElem instanceof RegExp) {
+          return allowedElem.test(clss);
+        }
+        return allowedElem.indexOf(clss) !== -1;
+      });
     }).join(' ');
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -587,8 +587,8 @@ function sanitizeHtml(html, options, _recursing) {
       return classes;
     }
     classes = classes.split(/\s+/);
-    return classes.filter(function (clss) {
-      return allowed.some(function (allowedElem) {
+    return classes.filter(function(clss) {
+      return allowed.some(function(allowedElem) {
         if (allowedElem instanceof RegExp) {
           return allowedElem.test(clss);
         }

--- a/test/test.js
+++ b/test/test.js
@@ -258,6 +258,20 @@ describe('sanitizeHtml', function() {
       '<p class="nifty">whee</p>'
     );
   });
+  it('should allow only classes that matches `allowedClasses` regex', function() {
+    assert.equal(
+      sanitizeHtml(
+        '<p class="nifty33 nifty2 dippy">whee</p>',
+        {
+          allowedTags: [ 'p' ],
+          allowedClasses: {
+            p: [ /^nifty\d{2}$/, /^d\w{4}$/ ]
+          }
+        }
+      ),
+      '<p class="nifty33 dippy">whee</p>'
+    );
+  });
   it('should allow defining schemes on a per-tag basis', function() {
     assert.equal(
       sanitizeHtml(


### PR DESCRIPTION
tests are passing:
![image](https://user-images.githubusercontent.com/22919198/144639985-e2dbe13d-90c3-461d-8da3-4b84d5c56d9e.png)
